### PR TITLE
Add Three-Tier AWS Infrastructure with Terraform

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,31 @@
+resource "aws_security_group" "ec2" {
+  name        = "ec2-security-group"
+  description = "Security group for EC2 instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.public.id
+
+  vpc_security_group_ids = [aws_security_group.ec2.id]
+
+  tags = {
+    Name = "web-server"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = "roberto-main"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "ec2_public_ip" {
+  value = aws_instance.web.public_ip
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.postgres.endpoint
+}

--- a/rds.tf
+++ b/rds.tf
@@ -1,0 +1,32 @@
+resource "aws_security_group" "rds" {
+  name        = "rds-security-group"
+  description = "Security group for RDS instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+  }
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier           = "postgres-db"
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine              = "postgres"
+  engine_version      = "13.7"
+  instance_class      = "db.t3.micro"
+  username            = "postgres"
+  password            = "password123"
+  skip_final_snapshot = true
+
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  db_subnet_group_name   = aws_db_subnet_group.default.name
+}
+
+resource "aws_db_subnet_group" "default" {
+  name       = "main"
+  subnet_ids = [aws_subnet.private.id]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,56 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "three-tier-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-subnet"
+  }
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "${var.aws_region}a"
+
+  tags = {
+    Name = "private-subnet"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main-igw"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
This PR implements a three-tier AWS infrastructure using Terraform, consisting of:

- VPC configuration with public and private subnets
- EC2 instance in public subnet with SSH access
- RDS PostgreSQL instance in private subnet
- Security groups for EC2 and RDS instances
- Necessary networking components (IGW, route tables)

Key components:
- VPC CIDR: 10.0.0.0/16
- Public subnet: 10.0.1.0/24
- Private subnet: 10.0.2.0/24
- t2.micro EC2 instance
- db.t3.micro PostgreSQL 13.7 RDS instance

The infrastructure is configured for the us-east-1 region with proper security group rules and network isolation between tiers.