### PR TITLE
Refactor infrastructure into modular 3-tier architecture

### DIFF
--- a/3tier/compute/main.tf
+++ b/3tier/compute/main.tf
@@ -1,0 +1,11 @@
+resource "aws_instance" "app" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+  subnet_id     = var.public_subnet_id
+
+  vpc_security_group_ids = [var.security_group_id]
+
+  tags = {
+    Name = "${var.environment}-app"
+  }
+}

--- a/3tier/compute/outputs.tf
+++ b/3tier/compute/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_id" {
+  value = aws_instance.app.id
+}
+
+output "public_ip" {
+  value = aws_instance.app.public_ip
+}

--- a/3tier/compute/variables.tf
+++ b/3tier/compute/variables.tf
@@ -1,0 +1,24 @@
+variable "ami_id" {
+  description = "AMI ID for EC2 instance"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "Instance type for EC2"
+  type        = string
+}
+
+variable "public_subnet_id" {
+  description = "Subnet ID for EC2 instance"
+  type        = string
+}
+
+variable "security_group_id" {
+  description = "Security group ID for EC2 instance"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}

--- a/3tier/database/main.tf
+++ b/3tier/database/main.tf
@@ -1,0 +1,20 @@
+resource "aws_db_instance" "main" {
+  identifier        = "${var.environment}-db"
+  engine           = var.engine
+  engine_version   = var.engine_version
+  instance_class   = var.instance_class
+  allocated_storage = var.allocated_storage
+
+  username = var.db_username
+  password = var.db_password
+
+  vpc_security_group_ids = [var.security_group_id]
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+
+  skip_final_snapshot = true
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.environment}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+}

--- a/3tier/database/outputs.tf
+++ b/3tier/database/outputs.tf
@@ -1,0 +1,7 @@
+output "endpoint" {
+  value = aws_db_instance.main.endpoint
+}
+
+output "port" {
+  value = aws_db_instance.main.port
+}

--- a/3tier/database/variables.tf
+++ b/3tier/database/variables.tf
@@ -1,0 +1,44 @@
+variable "engine" {
+  description = "Database engine type"
+  type        = string
+}
+
+variable "engine_version" {
+  description = "Database engine version"
+  type        = string
+}
+
+variable "instance_class" {
+  description = "Database instance class"
+  type        = string
+}
+
+variable "allocated_storage" {
+  description = "Allocated storage in GB"
+  type        = number
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Database master password"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "Security group ID for database"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}

--- a/3tier/vpc/main.tf
+++ b/3tier/vpc/main.tf
@@ -1,0 +1,78 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.environment}-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count             = length(var.public_subnets)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnets[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "${var.environment}-public-${count.index + 1}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnets)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnets[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "${var.environment}-private-${count.index + 1}"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.environment}-igw"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.environment}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnets)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "app" {
+  name        = "${var.environment}-app-sg"
+  description = "Security group for application tier"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/3tier/vpc/outputs.tf
+++ b/3tier/vpc/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}
+
+output "app_security_group_id" {
+  value = aws_security_group.app.id
+}

--- a/3tier/vpc/variables.tf
+++ b/3tier/vpc/variables.tf
@@ -1,0 +1,24 @@
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+}
+
+variable "public_subnets" {
+  description = "List of public subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "List of private subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# simple-vpc
+# Simple 3-Tier VPC Infrastructure
+
+This repository contains Terraform configurations for deploying a 3-tier VPC infrastructure with the following components:
+
+- VPC with public and private subnets
+- EC2 instances in the application tier
+- RDS database in the data tier
+
+## Module Structure
+
+```
+.
+├── main.tf           # Root module configuration
+├── variables.tf      # Root variables
+├── outputs.tf        # Root outputs
+├── terraform.tfvars  # Variable values
+└── 3tier/
+    ├── vpc/         # VPC module
+    ├── compute/     # Compute module
+    └── database/    # Database module
+```
+
+## Usage
+
+1. Initialize Terraform:
+```
+terraform init
+```
+
+2. Review the plan:
+```
+terraform plan
+```
+
+3. Apply the configuration:
+```
+terraform apply
+```
+
+## Variables
+
+See terraform.tfvars for default values. Key variables include:
+
+- vpc_cidr: VPC CIDR block
+- environment: Environment name (dev/staging/prod)
+- instance_type: EC2 instance type
+- db_instance_class: RDS instance class
+
+## Outputs
+
+- vpc_id: ID of the created VPC
+- app_instance_ip: Public IP of application instance
+- db_endpoint: RDS endpoint for connections

--- a/main.tf
+++ b/main.tf
@@ -11,3 +11,41 @@ terraform {
     }
   }
 }
+
+module "vpc" {
+  source = "./3tier/vpc"
+
+  vpc_cidr           = var.vpc_cidr
+  public_subnets     = var.public_subnets
+  private_subnets    = var.private_subnets
+  availability_zones = var.availability_zones
+  environment        = var.environment
+}
+
+module "compute" {
+  source = "./3tier/compute"
+
+  ami_id            = var.ami_id
+  instance_type     = var.instance_type
+  public_subnet_id  = module.vpc.public_subnet_ids[0]
+  security_group_id = module.vpc.app_security_group_id
+  environment       = var.environment
+
+  depends_on = [module.vpc]
+}
+
+module "database" {
+  source = "./3tier/database"
+
+  engine            = var.db_engine
+  engine_version    = var.db_engine_version
+  instance_class    = var.db_instance_class
+  allocated_storage = var.db_allocated_storage
+  db_username       = var.db_username
+  db_password       = var.db_password
+  private_subnet_ids = module.vpc.private_subnet_ids
+  security_group_id  = module.vpc.app_security_group_id
+  environment        = var.environment
+
+  depends_on = [module.vpc]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,14 @@
-output "ec2_public_ip" {
-  value = aws_instance.web.public_ip
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.vpc.vpc_id
 }
 
-output "rds_endpoint" {
-  value = aws_db_instance.postgres.endpoint
+output "app_instance_ip" {
+  description = "Public IP of the application instance"
+  value       = module.compute.public_ip
+}
+
+output "db_endpoint" {
+  description = "Database connection endpoint"
+  value       = module.database.endpoint
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,15 @@
+vpc_cidr = "10.0.0.0/16"
+public_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
+private_subnets = ["10.0.3.0/24", "10.0.4.0/24"]
+availability_zones = ["us-west-2a", "us-west-2b"]
+environment = "dev"
+
+ami_id = "ami-0c55b159cbfafe1f0"
+instance_type = "t2.micro"
+
+db_engine = "mysql"
+db_engine_version = "8.0"
+db_instance_class = "db.t3.micro"
+db_allocated_storage = 20
+db_username = "admin"
+db_password = "password123"

--- a/variables.tf
+++ b/variables.tf
@@ -7,5 +7,64 @@ variable "aws_region" {
 variable "vpc_cidr" {
   description = "CIDR block for VPC"
   type        = string
-  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "List of public subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "List of private subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instance"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "Instance type for EC2"
+  type        = string
+}
+
+variable "db_engine" {
+  description = "Database engine type"
+  type        = string
+}
+
+variable "db_engine_version" {
+  description = "Database engine version"
+  type        = string
+}
+
+variable "db_instance_class" {
+  description = "Database instance class"
+  type        = string
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage in GB"
+  type        = number
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Database master password"
+  type        = string
 }


### PR DESCRIPTION
This PR refactors the infrastructure configuration into a modular 3-tier architecture. The changes include:

### Module Structure
- Created three main modules:
  - `vpc`: VPC, subnets, route tables, and security groups
  - `compute`: EC2 instance configuration
  - `database`: RDS instance and subnet groups

### Key Changes
- Moved existing configurations from root `.tf` files into dedicated modules
- Added variable definitions and outputs for each module
- Created root module configuration to orchestrate the components
- Added comprehensive documentation in README.md
- Introduced terraform.tfvars with default values

### Module Dependencies
- Established proper module dependencies using `depends_on`
- Configured inter-module communication through outputs

### Documentation
- Updated README with new module structure
- Added usage instructions and variable documentation